### PR TITLE
#23 add npm script post install to bower install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "node": "^4.2.2",
     "npm": "^2.7.0"
   },
+  "scripts" : {
+    "postinstall": "bower install"
+  },
   "sasslintConfig": "sass-lint.yml",
   "devDependencies": {
     "adm-zip": "^0.4.7",


### PR DESCRIPTION
#23 add npm script post install to bower install

is util when we are install the project, we dont need run "bower install" after install packages.