### PR TITLE
chore(git): put ignored vendors back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,6 @@ linters/
 .Trash-*
 .directory
 
-### Composer ###
-vendor
-composer.lock
-
 ### Bower ###
 bower_components
 .bower-cache


### PR DESCRIPTION
We don't use composer in this case, but some plugins do. 

With this change we will keep the `vendor` folder for them.

Fixes #41 