### PR TITLE
Task to generate a new [css and js] file name on each `build`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5298,6 +5298,59 @@
         }
       }
     },
+    "gulp-cachebust": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/gulp-cachebust/-/gulp-cachebust-0.0.10.tgz",
+      "integrity": "sha512-VLkx8tPZAt5244KIogTNwdeHEFMxhtRlqRpoRQ3oq02UXDqVXb8eRC7YCa4WL65xLvbc7kPObd71OJvpFJ8AGg==",
+      "dev": true,
+      "requires": {
+        "plugin-error": "1.0.1",
+        "slash": "1.0.0",
+        "through2": "0.5.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+          "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "3.0.0"
+          }
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+          "dev": true
+        }
+      }
+    },
     "gulp-clean-css": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.9.3.tgz",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "start": "npm install && bower install && npm run init",
     "wp": "gulp wp-install && gulp wp-pre-build && npm run wp:plugins",
     "wp:dev": "npm run wp && gulp",
-    "wp:build": "npm run wp && gulp build",
-    "wp:plugins": "cp -r ./plugins ./wordpress/wp-content"
+    "wp:build": "npm run wp && gulp build && npm run assets-version",
+    "wp:plugins": "cp -r ./plugins ./wordpress/wp-content",
+    "assets-version": "gulp asssets-new-version"
   },
   "sasslintConfig": "sass-lint.yml",
   "devDependencies": {
@@ -33,6 +34,7 @@
     "gulp-autoprefixer": "^5.0.0",
     "gulp-babel": "^7.0.1",
     "gulp-cache": "^1.0.2",
+    "gulp-cachebust": "0.0.10",
     "gulp-clean-css": "^3.9.3",
     "gulp-concat": "^2.6.1",
     "gulp-connect-php": "1.0.3",

--- a/tasks/assets-version.js
+++ b/tasks/assets-version.js
@@ -1,0 +1,27 @@
+const gulp = require('gulp');
+const path = require('path');
+const CacheBust = require('gulp-cachebust');
+
+const cache = new CacheBust({
+	pathFormatter(dirname, basename, extname, checksum) {
+		return path.join(dirname, basename + '.' + checksum + extname);
+	}
+});
+
+gulp.task('new-version-css', function () {
+	return gulp.src(gulp.paths.stylesDest + '/*.css')
+		.pipe(cache.resources())
+		.pipe(gulp.dest(gulp.paths.stylesDest));
+});
+
+gulp.task('new-version-js', function () {
+	return gulp.src(gulp.paths.scriptsDest + '/*.js')
+		.pipe(cache.resources())
+		.pipe(gulp.dest(gulp.paths.scriptsDest));
+});
+
+gulp.task('asssets-new-version', ['new-version-css', 'new-version-js'], function () {
+	return gulp.src(gulp.paths.pages)
+		.pipe(cache.references())
+		.pipe(gulp.dest(gulp.paths.pagesDest));
+});


### PR DESCRIPTION
## before

```
├── css
│   ├── libs.min.css
│   ├── main.min.css
├── js
│   ├── libs.min.js
│   ├── main.min.js

```

## after

```
├── css
│   ├── libs.min.f10ad922.css
│   ├── main.min.08cc4bf0.css
├── js
│   ├── libs.min.f648c5b3.js
│   ├── main.min.5721e1d3.js

```

This is called inside `wp:build` becase we run it on each deployment process.