### PR TITLE
allow localhost as name and ip

### DIFF
--- a/tasks/config/wordpress/wp-config.php
+++ b/tasks/config/wordpress/wp-config.php
@@ -1,7 +1,7 @@
 <?php
 
 $domains = [
-	'development' => ['localhost'],
+	'development' => ['localhost', '127.0.0.1'],
 	'production' => ['production.com.br'],
 	'staging' => ['staging.com.br']
 ];
@@ -11,7 +11,7 @@ $currentDomain = str_replace('www.', '', $_SERVER['HTTP_HOST']);
 foreach ($domains as $key => $group) {
 	foreach ($group as $domain) {
 		if (strpos($currentDomain, $domain) !== false) {
-			include 'wp-config-'.$key.'.php';
+			include 'wp-config-' . $key . '.php';
 			break;
 		}
 	}


### PR DESCRIPTION
This PR fixes the error `Uncaught Error: Call to undefined function wp()...` that occurs (only on the log) when we run the project.