### PR TITLE
Task to load custom critical/first-view css as Internal

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,9 @@ gulp.task('watch', () => {
 	const paths = Object.keys(developmentPaths);
 
 	paths.map(path => {
+		const task = path;
+
 		// Combine each development path with a task
-		return gulp.watch(gulp.paths[path], [path]);
+		return gulp.watch(gulp.paths[path], [task]);
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1166,6 +1166,12 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
+    "binaryextensions": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.1.tgz",
+      "integrity": "sha1-HmN0iLNbWL2l9HdL+WpSEqjJB1U=",
+      "dev": true
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -5829,6 +5835,17 @@
       "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=",
       "dev": true
     },
+    "gulp-replace": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-0.6.1.tgz",
+      "integrity": "sha1-Eb+Mj85TPjPi9qjy9DC5VboL4GY=",
+      "dev": true,
+      "requires": {
+        "istextorbinary": "1.0.2",
+        "readable-stream": "2.3.6",
+        "replacestream": "4.0.3"
+      }
+    },
     "gulp-sass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-4.0.1.tgz",
@@ -6926,6 +6943,16 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "istextorbinary": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
+      "integrity": "sha1-rOGTVNGpoBc+/rEITOD4ewrX3s8=",
+      "dev": true,
+      "requires": {
+        "binaryextensions": "1.0.1",
+        "textextensions": "1.0.2"
+      }
     },
     "jpegtran-bin": {
       "version": "3.2.0",
@@ -9473,6 +9500,17 @@
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
+    "replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.6"
+      }
+    },
     "request": {
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
@@ -10702,6 +10740,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "textextensions": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz",
+      "integrity": "sha1-ZUhjk+4fK7A5pgy7oFsLaL2VAdI=",
       "dev": true
     },
     "tfunk": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "start": "npm install && bower install && npm run init",
     "wp": "gulp wp-install && gulp wp-pre-build && npm run wp:plugins",
     "wp:dev": "npm run wp && gulp",
-    "wp:build": "npm run wp && gulp build && npm run assets-version",
+    "wp:build": "npm run wp && gulp build && npm run assets-version && npm run inline-css",
     "wp:plugins": "cp -r ./plugins ./wordpress/wp-content",
+    "inline-css": "gulp inline-css",
     "assets-version": "gulp asssets-new-version"
   },
   "sasslintConfig": "sass-lint.yml",
@@ -46,6 +47,7 @@
     "gulp-main-bower-files": "^1.6.2",
     "gulp-plumber": "^1.2.0",
     "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.6.1",
     "gulp-sass": "^4.0.1",
     "gulp-sass-lint": "^1.3.4",
     "gulp-sourcemaps": "^2.6.4",

--- a/src/css/first-view.sass
+++ b/src/css/first-view.sass
@@ -1,0 +1,9 @@
+// tools
+@import "tools/mixins"
+
+// settings
+@import "settings/colors"
+@import "settings/measures"
+
+// components
+@import "components/header"

--- a/src/css/main.sass
+++ b/src/css/main.sass
@@ -14,7 +14,6 @@
 @import "elements/buttons"
 
 // components
-@import "components/header"
 @import "components/footer"
 @import "components/menu"
 

--- a/src/footer.php
+++ b/src/footer.php
@@ -1,0 +1,4 @@
+		<script src="<?php echo get_bloginfo('template_url') ?>/js/libs.min.js" defer></script>
+		<script src="<?php echo get_bloginfo('template_url') ?>/js/main.min.js" defer></script>
+	</body>
+</html>

--- a/src/header.php
+++ b/src/header.php
@@ -6,6 +6,8 @@
 		<meta charset="utf-8"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
+		<link inject-first-view-css href="<?php echo get_bloginfo('template_url') ?>/css/first-view.min.css" rel="stylesheet">
+
 		<link href="<?php echo get_bloginfo('template_url') ?>/css/libs.min.css" rel="stylesheet"/>
 		<link href="<?php echo get_bloginfo('template_url') ?>/css/main.min.css" rel="stylesheet"/>
 	</head>

--- a/src/header.php
+++ b/src/header.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Grão de Milho</title>
+
+		<meta charset="utf-8"/>
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+
+		<link href="<?php echo get_bloginfo('template_url') ?>/css/libs.min.css" rel="stylesheet"/>
+		<link href="<?php echo get_bloginfo('template_url') ?>/css/main.min.css" rel="stylesheet"/>
+	</head>
+	<body>

--- a/src/index.php
+++ b/src/index.php
@@ -1,10 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-	<meta charset="UTF-8">
-	<title></title>
-</head>
-<body>
-	<strong>It works!</strong>
-</body>
-</html>
+<?php get_header() ?>
+
+<main>
+
+</main>
+
+<?php get_footer() ?>

--- a/tasks/inline-css.js
+++ b/tasks/inline-css.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const gulp = require('gulp');
+const replace = require('gulp-replace');
+const browserSync = require('browser-sync');
+
+gulp.task('inline-css', function() {
+	const file = `${gulp.paths.stylesDest}/first-view.min.css`;
+
+	if (!fs.existsSync(file)) {
+		return false;
+	}
+
+	const inject = /<link\s*inject-first-view-css\s*(.*\>?)>/gi;
+	const comments = /\/\*[^*]*.*?\*\//;
+
+	const css = fs.readFileSync(file, 'utf8');
+	const style = css.replace(comments, '').trim();
+
+	return gulp.src([`${gulp.paths.pagesDest}**/*.php`])
+		.pipe(replace(inject, () => `<style>${style}</style>`))
+		.pipe(gulp.dest(gulp.paths.themesWp));
+});


### PR DESCRIPTION
Importing some components inside [`src/css/first-view.sass`](https://github.com/pipocadigital/grao-de-milho/blob/695b6f7cbaff964569690e16b59ccac0b534605a/src/css/first-view.sass) will inject them as inline `<style>` after run [`npm run wp:build`](https://github.com/pipocadigital/grao-de-milho/blob/695b6f7cbaff964569690e16b59ccac0b534605a/package.json#L21) on each deploy. 

The first `<link>` with a [`inject-first-view-css`](https://github.com/pipocadigital/grao-de-milho/blob/695b6f7cbaff964569690e16b59ccac0b534605a/src/header.php#L9) attribute will be replaced.

By default this css file doesn't load anything.

For development environment we're loading this file using `<link ...>`.
